### PR TITLE
Fixes for Zinc 3.4 plus broken tests

### DIFF
--- a/src/interface/material.i
+++ b/src/interface/material.i
@@ -16,6 +16,7 @@
 %include "doublevaluesarraytypemap.i"
 %include "pyzincstringhandling.i"
 
+%import "context.i"
 %import "field.i"
 %import "font.i"
 

--- a/src/interface/region.i
+++ b/src/interface/region.i
@@ -17,6 +17,7 @@
 %typemap(in) (const char *path) = (const char *name);
 %typemap(in) (const char *fileName) = (const char *name);
 
+%import "context.i"
 %import "fieldmodule.i"
 %import "scene.i"
 %import "streamregion.i"

--- a/tests/python/field_tests/vectoroperatortests.py
+++ b/tests/python/field_tests/vectoroperatortests.py
@@ -28,24 +28,43 @@ class VectorOperatorTestCase(unittest.TestCase):
         del self.context
 
     def testCrossProductCreate(self):
-        self.assertRaises(NotImplementedError, self.field_module.createFieldCrossProduct)
+        self.assertRaises(TypeError, self.field_module.createFieldCrossProduct)
         self.assertRaises(TypeError, self.field_module.createFieldCrossProduct, [0])
         f = self.field_module.createFieldConstant([1, 2])
         cp = self.field_module.createFieldCrossProduct([f])
         self.assertTrue(cp.isValid())
 
-    def testCrossProductOverload1(self):
+    def testCrossProductOverload1Valid(self):
         f1 = self.field_module.createFieldConstant([1, 2, 3])
         f2 = self.field_module.createFieldConstant([4, 5, 6])
         cp = self.field_module.createFieldCrossProduct(f1, f2)
         self.assertTrue(cp.isValid())
-        
-    def testCrossProductOverload2(self):
+
+    def testCrossProductOverload1Invalid(self):
         f1 = self.field_module.createFieldConstant([1, 2])
         f2 = self.field_module.createFieldConstant([4, 5])
         cp = self.field_module.createFieldCrossProduct(f1, f2)
         self.assertFalse(cp.isValid())
-        
+
+    def testCrossProductOverload2Valid(self):
+        f1 = self.field_module.createFieldConstant([1, 2, 3])
+        f2 = self.field_module.createFieldConstant([4, 5, 6])
+        cp = self.field_module.createFieldCrossProduct([f1, f2])
+        self.assertTrue(cp.isValid())
+
+    def testCrossProductOverload2Invalid(self):
+        f1 = self.field_module.createFieldConstant([1, 2])
+        f2 = self.field_module.createFieldConstant([4, 5])
+        cp = self.field_module.createFieldCrossProduct([f1, f2])
+        self.assertFalse(cp.isValid())
+
+    def testDotProductCreate(self):
+        self.assertRaises(TypeError, self.field_module.createFieldDotProduct)
+        self.assertRaises(TypeError, self.field_module.createFieldDotProduct, [0])
+        f = self.field_module.createFieldConstant([1, 2])
+        dp = self.field_module.createFieldDotProduct(f, f)
+        self.assertTrue(dp.isValid())
+
 def suite():
     #import ImportTestCase
     tests = unittest.TestSuite()

--- a/tests/python/graphics_tests/graphicstests.py
+++ b/tests/python/graphics_tests/graphicstests.py
@@ -11,6 +11,7 @@ Created on May 22, 2013
 
 @author: hsorby
 '''
+import os
 import unittest
 
 from opencmiss.zinc.context import Context
@@ -79,45 +80,57 @@ class GraphicsTestCase(unittest.TestCase):
         sv = svm.createSceneviewer(Sceneviewer.BUFFERING_MODE_DOUBLE, Sceneviewer.STEREO_MODE_MONO)
         
         result = sv.setBackgroundColourComponentRGB(0.3, 0.8, 0.65)
-        self.assertEqual(1, result)
+        self.assertEqual(status.OK, result)
         (result, rgb) = sv.getBackgroundColourRGB()
-        self.assertEqual(1, result)
+        self.assertEqual(status.OK, result)
         self.assertEqual([0.3, 0.8, 0.65], rgb)
         
         result = sv.setBackgroundColourRGB([0.1, 0.9, 0.4])
-        self.assertEqual(1, result)
+        self.assertEqual(status.OK, result)
         (result, rgb) = sv.getBackgroundColourRGB()
-        self.assertEqual(1, result)
+        self.assertEqual(status.OK, result)
         self.assertEqual([0.1, 0.9, 0.4], rgb)
         
         self.assertRaises(TypeError, sv.setBackgroundColourRGB, [3.0, 2.0])
         
     def testSceneExport(self):
-        self.root_region.readFile('resource/cube.exformat')
+        path = os.path.dirname(os.path.realpath(__file__))
+        result = self.root_region.readFile(path + '/../resource/cube.exformat')
+        self.assertEqual(status.OK, result)
         surfaces = self.scene.createGraphicsSurfaces()
-        coordinatesField = self.root_region.getFieldmodule().findFieldByName("coordinates");
+        coordinatesField = self.root_region.getFieldmodule().findFieldByName("coordinates")
+        self.assertTrue(coordinatesField.isValid())
         result = surfaces.setCoordinateField(coordinatesField)
-        self.assertEqual(1, result)
-        si = self.scene.createStreaminformationScene();
+        self.assertEqual(status.OK, result)
+        si = self.scene.createStreaminformationScene()
         si.setIOFormat(si.IO_FORMAT_THREEJS)
         result = si.getNumberOfResourcesRequired()
         self.assertEqual(2, result)
         result = si.setIODataType(si.IO_DATA_TYPE_COLOUR)
-        self.assertEqual(1, result)
-        memeory_sr = si.createStreamresourceMemory();
+        self.assertEqual(status.OK, result)
+        memory_sr1 = si.createStreamresourceMemory()
+        memory_sr2 = si.createStreamresourceMemory()
         result = self.scene.write(si)
-        self.assertEqual(1, result)
-        result, outputstring = memeory_sr.getBuffer()
-        self.assertEqual(1, result)
-        stringLoc = outputstring.find('vertices')
-        self.assertNotEqual(-1, stringLoc, 'keyword \'vertices\' not found')
+        self.assertEqual(status.OK, result)
+        result, outputBytes1 = memory_sr1.getBuffer()
+        self.assertEqual(status.OK, result)
+        self.assertIsNotNone(outputBytes1)
+        self.assertTrue(b'Surfaces' in outputBytes1, 'keyword \'vertices\' not found')
+        result, outputBytes2 = memory_sr2.getBuffer()
+        self.assertEqual(status.OK, result)
+        self.assertIsNotNone(outputBytes2)
+        self.assertTrue(b'vertices' in outputBytes2, 'keyword \'vertices\' not found')
         
     def testGraphicsToGlyph(self):
-        self.root_region.readFile('resource/cube.exformat')
+        path = os.path.dirname(os.path.realpath(__file__))
+        print(path + '/../resource/cube.exformat')
+        result = self.root_region.readFile(path + '/../resource/cube.exformat')
+        self.assertEqual(status.OK, result)
         surfaces = self.scene.createGraphicsSurfaces()
-        coordinatesField = self.root_region.getFieldmodule().findFieldByName("coordinates");
+        coordinatesField = self.root_region.getFieldmodule().findFieldByName("coordinates")
+        self.assertTrue(coordinatesField.isValid())
         result = surfaces.setCoordinateField(coordinatesField)
-        self.assertEqual(1, result)
+        self.assertEqual(status.OK, result)
         glyphModule = self.context.getGlyphmodule()
         glyph = glyphModule.createStaticGlyphFromGraphics(surfaces)
         self.assertTrue(glyph.isValid())

--- a/tests/python/region_tests/regiontests.py
+++ b/tests/python/region_tests/regiontests.py
@@ -39,6 +39,12 @@ class RegionTestCase(unittest.TestCase):
         self.assertTrue(tr.isValid())
         self.findRegion(rr, '/bob/rick/mark')
 
+    def testGetContext(self):
+        rr = self.c.getDefaultRegion()
+        context = rr.getContext()
+        self.assertTrue(context.isValid())
+        self.assertEqual(context, self.c)
+
     def testWriteFieldNames(self):
         """
         This also tests SWIG typemaps for passing strings and lists of string
@@ -50,19 +56,19 @@ class RegionTestCase(unittest.TestCase):
         bob = fm.createFieldFiniteElement(1)
         self.assertTrue(bob.isValid())
         # following calls test SWIG wrappers for setting/getting single strings
-        self.assertEquals(RESULT_OK, bob.setName("bob"))
-        self.assertEquals("bob", bob.getName())
+        self.assertEqual(RESULT_OK, bob.setName("bob"))
+        self.assertEqual("bob", bob.getName())
         fred = fm.createFieldFiniteElement(1)
         self.assertTrue(fred.isValid())
-        self.assertEquals(RESULT_OK, fred.setName("fred"))
+        self.assertEqual(RESULT_OK, fred.setName("fred"))
         joe = fm.createFieldFiniteElement(1)
         self.assertTrue(joe.isValid())
-        self.assertEquals(RESULT_OK, joe.setName("joe"))
+        self.assertEqual(RESULT_OK, joe.setName("joe"))
         nodes = fm.findNodesetByFieldDomainType(Field.DOMAIN_TYPE_NODES)
         nt = nodes.createNodetemplate()
-        self.assertEquals(RESULT_OK, nt.defineField(bob))
-        self.assertEquals(RESULT_OK, nt.defineField(fred))
-        self.assertEquals(RESULT_OK, nt.defineField(joe))
+        self.assertEqual(RESULT_OK, nt.defineField(bob))
+        self.assertEqual(RESULT_OK, nt.defineField(fred))
+        self.assertEqual(RESULT_OK, nt.defineField(joe))
         node = nodes.createNode(1, nt)
         self.assertTrue(node.isValid())
 
@@ -84,9 +90,9 @@ class RegionTestCase(unittest.TestCase):
         self.assertEqual(RESULT_OK, result)
         result, output = mr.getBuffer()
         self.assertEqual(RESULT_OK, result)
-        self.assertTrue("bob" in output)
-        self.assertFalse("fred" in output)
-        self.assertTrue("joe" in output)
+        self.assertTrue(b"bob" in output)
+        self.assertFalse(b"fred" in output)
+        self.assertTrue(b"joe" in output)
 
 def suite():
     #import ImportTestCase


### PR DESCRIPTION
Requires all current Zinc PRs (up to opencmiss/zinc#181) to be pulled in for all tests to pass.
Note RUN_TESTS target is not reporting any tests that fail.